### PR TITLE
Group Compose compiler into Kotlin update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"config:base"
-	]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:base"
+	],
+	"packageRules": [
+		{
+			// Compose compiler is tightly coupled to Kotlin version.
+			"groupName": "Kotlin/Compose",
+			"matchPackagePrefixes": [
+				"androidx.compose.compiler:compiler",
+				"org.jetbrains.kotlin:kotlin-gradle-plugin",
+			],
+		},
+	],
+}


### PR DESCRIPTION
Not sure if you want this. Compose 1.5.2 isn't compatible with kotlin 1.9.0 so a combined update PR would be wedged.