### PR TITLE
Remove translations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,8 @@ android {
 		signingConfig signingConfigs.upload
 
 		buildConfigField 'String', 'POCKET_CONSUMER_KEY', "\"${propOrEmpty('SA4P_POCKET_CONSUMER_KEY')}\""
+
+		resConfigs('en')
 	}
 
 	buildTypes {


### PR DESCRIPTION
Unless our strings are also translated, do not embed translations for languages from libraries that we do not support.