### PR TITLE
Compat edge-to-edge for three-button nav bar

### DIFF
--- a/app/src/main/kotlin/com/jakewharton/sa4p/UiActivity.kt
+++ b/app/src/main/kotlin/com/jakewharton/sa4p/UiActivity.kt
@@ -6,7 +6,6 @@ import android.content.res.Configuration.UI_MODE_NIGHT_MASK
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.graphics.Color.TRANSPARENT
 import android.os.Bundle
-import android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
@@ -27,7 +26,7 @@ class UiActivity : ComponentActivity() {
 		)
 		// Fix for three-button nav not properly going edge-to-edge.
 		//  TODO https://issuetracker.google.com/issues/298296168
-		window.setFlags(FLAG_LAYOUT_NO_LIMITS, FLAG_LAYOUT_NO_LIMITS)
+		window.isNavigationBarContrastEnforced = false
 
 		val app = application as Sa4pApp
 		val db = app.db


### PR DESCRIPTION
This is a more compatible way for devices like Samsung.

| Before (Pixel 6 Android 15) | After (Pixel 6 Android 15) |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/90064e18-43cb-49f4-8545-46b5d726ff04) | ![after](https://github.com/user-attachments/assets/ae3d2e98-b462-4eb2-a911-682799438f4a) |

